### PR TITLE
Use a static UUID for the xhyve driver so that if you re-create, then…

### DIFF
--- a/pkg/minikube/cluster/cluster_darwin.go
+++ b/pkg/minikube/cluster/cluster_darwin.go
@@ -64,5 +64,6 @@ func createXhyveHost(config MachineConfig) *xhyveDriver {
 		DiskSize:       int64(config.DiskSize),
 		Virtio9p:       true,
 		Virtio9pFolder: "/Users",
+		UUID:           "F4BB3F79-AB4E-4708-95CA-E32FBFCDEFD3",
 	}
 }


### PR DESCRIPTION
… you will get same IP address again.

Depends on the xhyve driver merging the following PR:
https://github.com/zchee/docker-machine-driver-xhyve/pull/133