### PR TITLE
Updated options for --vm-driver option in minishift start doc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,7 +96,8 @@ $(GOPATH)/bin/gh-release:
 .PHONY: gendocs
 gendocs: $(shell find cmd) pkg/minikube/cluster/assets.go
 	$(MKGOPATH)
-	cd $(GOPATH)/src/$(REPOPATH) && go run -ldflags="$(MINIKUBE_LDFLAGS)" gen_help_text.go
+	# https://github.com/golang/go/issues/15038#issuecomment-207631885 ( CGO_ENABLED=0 )
+	cd $(GOPATH)/src/$(REPOPATH) && CGO_ENABLED=0 go run -ldflags="$(MINIKUBE_LDFLAGS)" -tags gendocs gen_help_text.go
 
 .PHONY: release
 release: clean deploy/iso/minishift.iso test $(GOPATH)/bin/gh-release cross

--- a/docs/minishift_start.md
+++ b/docs/minishift_start.md
@@ -25,7 +25,7 @@ minishift start
       --iso-url="https://github.com/jimmidyson/minishift/releases/download/v0.6.0/boot2docker.iso": Location of the minishift iso
       --memory=1024: Amount of RAM allocated to the minishift VM
       --registry-mirror=[]: Registry mirrors to pass to the Docker daemon
-      --vm-driver="kvm": VM driver is one of: [virtualbox kvm]
+      --vm-driver="kvm": VM driver is one of: [virtualbox vmwarefusion kvm xhyve hyperv]
 ```
 
 ### Options inherited from parent commands

--- a/pkg/minikube/constants/constants.go
+++ b/pkg/minikube/constants/constants.go
@@ -60,6 +60,7 @@ const (
 	DefaultMemory   = 1024
 	DefaultCPUS     = 1
 	DefaultDiskSize = "20g"
+	DefaultVMDriver = "kvm"
 )
 
 var DefaultIsoUrl = "https://github.com/jimmidyson/minishift/releases/download/v" + version.GetVersion() + "/boot2docker.iso"

--- a/pkg/minikube/constants/constants_darwin.go
+++ b/pkg/minikube/constants/constants_darwin.go
@@ -1,3 +1,5 @@
+// +build darwin,!gendocs
+
 /*
 Copyright (C) 2016 Red Hat, Inc.
 
@@ -21,7 +23,3 @@ var SupportedVMDrivers = [...]string{
 	"vmwarefusion",
 	"xhyve",
 }
-
-const (
-	DefaultVMDriver = "xhyve"
-)

--- a/pkg/minikube/constants/constants_gendocs.go
+++ b/pkg/minikube/constants/constants_gendocs.go
@@ -1,4 +1,4 @@
-// +build linux,!gendocs
+// +build gendocs
 
 /*
 Copyright (C) 2016 Red Hat, Inc.
@@ -20,5 +20,8 @@ package constants
 
 var SupportedVMDrivers = [...]string{
 	"virtualbox",
+	"vmwarefusion",
 	"kvm",
+	"xhyve",
+	"hyperv",
 }

--- a/pkg/minikube/constants/constants_windows.go
+++ b/pkg/minikube/constants/constants_windows.go
@@ -1,3 +1,5 @@
+// +build windows,!gendocs
+
 /*
 Copyright (C) 2016 Red Hat, Inc.
 
@@ -20,7 +22,3 @@ var SupportedVMDrivers = [...]string{
 	"virtualbox",
 	"hyperv",
 }
-
-const (
-	DefaultVMDriver = "hyperv"
-)


### PR DESCRIPTION
[README](https://github.com/jimmidyson/minishift#quickstart) mentioned four vm driver options. Hence updated in the minishift start doc. 